### PR TITLE
Add purejin

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,3 +374,4 @@ Alternate setup if the IDE doesn't detect the processor:
 
 - [NetBeans Lookup](https://search.maven.org/search?q=g:org.netbeans.api%20AND%20a:org-openide-util-lookup&core=gav)
 - [Google AutoServive](https://www.baeldung.com/google-autoservice)
+- [purejin - PURE Java INjection](http://jbee.github.io/purejin/)


### PR DESCRIPTION
I appreciate that other related frameworks are linked. I see that not all related frameworks are linked. Neverthless, I wanted to provide the googlers for a complete-oppsite approach: purejin

> purejin is a Java dependency injection library that only uses vanilla Java code to define a container context using a fluent binding API.
>
> It does not use annotations for injection guidance, avoids proxies, bytecode manipulation/interception or any other technique based on conventions that have to be learned.

Maybe, you also find it interesting to provide a link.

(Background: I am personally still in the process to pin a depdencency injection framework for JabRef - and currently, we tend to "stick" with our [afterburner.fx fork](https://github.com/JabRef/afterburner.fx/tree/main/src/main/java/com/airhacks/afterburner/injection), but are also looking in parallel for other options)