### PR TITLE
Add purejin as related work

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,3 +374,4 @@ Alternate setup if the IDE doesn't detect the processor:
 
 - [NetBeans Lookup](https://search.maven.org/search?q=g:org.netbeans.api%20AND%20a:org-openide-util-lookup&core=gav)
 - [Google AutoServive](https://www.baeldung.com/google-autoservice)
+- [purejin](https://github.com/jbee/purejin)

--- a/README.md
+++ b/README.md
@@ -374,4 +374,4 @@ Alternate setup if the IDE doesn't detect the processor:
 
 - [NetBeans Lookup](https://search.maven.org/search?q=g:org.netbeans.api%20AND%20a:org-openide-util-lookup&core=gav)
 - [Google AutoServive](https://www.baeldung.com/google-autoservice)
-- [purejin](https://github.com/jbee/purejin)
+- [`purejin`](https://github.com/jbee/purejin)


### PR DESCRIPTION
Thank you for listing related work.

I think, `purejin` should be added. "PURE Java INjection". I was impressed by the design ideas. Thus, it should IMHO be listed

> It does not use annotations for injection guidance, avoids proxies, bytecode manipulation/interception or any other technique based on conventions that have to be learned.
>
> It only uses vanilla Java code and reflection to build an applications object graph as if it was connected manually based on the bindings made using its fluent API.
>
> Purejin is pure. It does not depend on other languages, other Java libraries or mechanisms that work by convention. It’s just Java with reflection (no unsafe). This has the added benefit that it can be debugged and understood like a standard Java application.

(Source: https://jbee.github.io/purejin/)